### PR TITLE
文档：建立学习型研发流程与任务编排基础

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing Guide
+
+## Collaboration Model
+
+`ZLD SupportPilot` is maintained as a production-style portfolio project. The repository uses lightweight team conventions so work can be demonstrated in a realistic GitHub flow.
+
+## Workflow
+
+1. Start from an open GitHub issue.
+2. Create a branch with the `codex/*` prefix.
+3. Keep each PR focused on one issue or one tightly related slice.
+4. Run local validation before opening or updating a PR.
+5. Merge only after the PR description clearly explains scope, risk, and validation.
+
+## Branch Naming
+
+- `codex/bootstrap-repo`
+- `codex/auth-rbac-foundation`
+- `codex/ticket-workflow`
+- `codex/rag-answer-api`
+
+## Pull Requests
+
+- Link the issue in the PR body with `Closes #<number>`
+- Describe `What`, `Why`, `How`, `Risk`, and `Validation`
+- Keep PRs small enough to review in one sitting
+
+## Milestones
+
+- `M1 - Foundation`: bootstrap, environment, auth foundation
+- `M2 - Ticket & Knowledge`: ticket workflow, document ingestion, retrieval preparation
+- `M3 - AI & Ops`: RAG, AI assistance, observability, release polish
+
+## Verification
+
+For Go code changes, run:
+
+```bash
+gofmt -w ./cmd ./internal ./pkg
+go test ./...
+```
+
+For documentation-only changes, verify links and referenced issue numbers are still correct.
+

--- a/README.md
+++ b/README.md
@@ -60,3 +60,13 @@ curl http://localhost:8080/healthz
 - Milestone 4: Knowledge Base + RAG
 - Milestone 5: AI Assistant + Observability
 
+## Delivery Workflow
+
+This repository follows an issue-first, PR-based delivery workflow.
+
+- Roadmap issues are grouped into GitHub milestones
+- Each implementation slice should start from an issue
+- Feature and task branches use the `codex/*` prefix
+- All changes land through PRs, even for documentation-only work
+
+See `CONTRIBUTING.md` and `docs/plans/2026-03-07-delivery-roadmap.md` for the initial collaboration and milestone plan.

--- a/docs/plans/2026-03-07-delivery-roadmap.md
+++ b/docs/plans/2026-03-07-delivery-roadmap.md
@@ -1,0 +1,35 @@
+# ZLD SupportPilot Delivery Roadmap
+
+## Positioning
+
+This roadmap captures the first delivery slices for `ZLD SupportPilot`, a Go-based intelligent service desk backend for enterprise support scenarios.
+
+## Milestones
+
+### M1 - Foundation
+
+- `#1` Define delivery workflow and roadmap
+- `#2` Build tenant, auth and RBAC foundation
+
+### M2 - Ticket & Knowledge
+
+- `#3` Implement ticket domain and workflow
+- `#4` Add ticket collaboration and audit events
+- `#5` Add knowledge base and document upload flow
+- `#6` Build async document processing pipeline
+
+### M3 - AI & Ops
+
+- `#7` Implement retrieval and RAG answer API
+- `#8` Add AI classification, summary and draft reply flows
+- `#9` Add observability, rate limiting and release polish
+
+## Working Agreement
+
+- Each roadmap slice should have a dedicated PR
+- Documentation and architecture updates land alongside implementation when relevant
+- New features should preserve the module boundaries defined in `docs/architecture/overview.md`
+
+## Near-Term Goal
+
+The immediate next delivery objective is to complete the foundation story: repository workflow, local environment expectations, and tenant-aware auth groundwork.


### PR DESCRIPTION
## 背景

当前仓库已经有基础 Go 骨架，但还没有一套“学习型研发”的方法层。后续如果直接进入业务功能开发，会缺少研究过程、任务编排、中文沉淀和依赖编排标准。

## 本次改动

### 1. 建立 M0 方法层
- 新增 `M0 - 方法与协作基础`
- 新增方法层主线 / 并行 / 融合 issues：`#11`、`#12`、`#13`、`#14`
- 将已有业务 issues 统一改成中文，并补充主线 / 并行 / 融合语义

### 2. 建立统一模板
- 新增 `docs/templates/`
- 固定每个 issue 的 7 件套工作包模板
- 新增 `docs/workitems/` 作为按 issue 维度沉淀完整工作过程的目录

### 3. 建立任务编排文档
- 新增 `docs/coordination/当前Issue依赖与并发分析.md`
- 新增 `docs/coordination/执行波次规划.md`
- 新增 `docs/coordination/M0-方法层融合检查表.md`
- 明确哪些 issue 必须串行、哪些可以并行、哪些要通过融合 issue 收口

### 4. 建立双层 skill
- 新增通用 skill：`skills/learning-rd-workflow/`
- 新增项目 skill：`skills/zld-supportpilot-delivery/`
- 两个 skill 都已通过结构校验

### 5. 补齐方法层工作包
- `docs/workitems/issue-011-学习型研发流程与任务编排规范/`
- `docs/workitems/issue-012-通用学习型研发工作流skill/`
- `docs/workitems/issue-013-zld项目交付skill/`
- `docs/workitems/issue-014-统一模板技能与GitHub工作流/`

### 6. 为下一阶段准备开工包
- 新增 `docs/workitems/issue-002-认证-租户与RBAC基础/`
- 新增 `docs/plans/2026-03-07-auth-rbac-foundation-implementation-plan.md`
- 让 `#2` 可以在 M0 收口后按统一规范正式开工

## 实现方式

- 在仓库内同时建立“模板层、协作层、工作包层、技能层”四层结构
- 通过 GitHub issue / PR 中文化，把线上协作入口和仓库内文档统一到同一套术语
- 通过依赖分析、执行波次和融合检查表，把后续业务开发改造成“先编排、再实现”的方式

## 验证结果

- [x] `python3 /Users/liuche/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/learning-rd-workflow`
- [x] `python3 /Users/liuche/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/zld-supportpilot-delivery`
- [x] `go test ./...`
- [x] 已检查 issue、milestone、PR 与本地文档术语一致
- [x] 已通过 `docs/coordination/M0-方法层融合检查表.md` 校验进入下一阶段的门槛

## 风险影响

- 当前改动主要是方法层和文档层，对业务代码没有直接风险
- 后续如果路线图和 issue 拆分调整，需要同步更新 coordination 文档和项目 skill

## 关联文档

- `docs/plans/2026-03-07-method-foundation-implementation-plan.md`
- `docs/plans/2026-03-07-auth-rbac-foundation-implementation-plan.md`
- `docs/coordination/当前Issue依赖与并发分析.md`
- `docs/coordination/执行波次规划.md`
- `docs/coordination/M0-方法层融合检查表.md`
- `docs/workitems/issue-011-学习型研发流程与任务编排规范/`
- `docs/workitems/issue-012-通用学习型研发工作流skill/`
- `docs/workitems/issue-013-zld项目交付skill/`
- `docs/workitems/issue-014-统一模板技能与GitHub工作流/`
- `docs/workitems/issue-002-认证-租户与RBAC基础/`

## 关闭 Issue

Closes #11
Refs #12
Refs #13
Refs #14
Refs #2
